### PR TITLE
support batch_norm

### DIFF
--- a/create_yolo_caffemodel.py
+++ b/create_yolo_caffemodel.py
@@ -53,20 +53,67 @@ def main(argv):
 	print netWeights.shape
 	count = 0
 	for pr in params:
-		biasSize = np.prod(net.params[pr][1].data.shape)
-		net.params[pr][1].data[...] = np.reshape(netWeights[count:count+biasSize], net.params[pr][1].data.shape)
-		count = count + biasSize
-		weightSize = np.prod(net.params[pr][0].data.shape)
-		if pr[0:2]=='co': # convolutional layer
-			net.params[pr][0].data[...] = np.reshape(netWeights[count:count+weightSize], net.params[pr][0].data.shape)
-		else: # fc layer
+		lidx = list(net._layer_names).index(pr)
+		layer = net.layers[lidx]
+		if count == netWeights.shape[0] and (layer.type != 'BatchNorm' and layer.type != 'Scale'):
+			print "WARNING: no weights left for %s" % pr
+			break
+		if layer.type == 'Convolution':
+			print pr+"(conv)"
+			# bias
+			if len(net.params[pr]) > 1:
+				bias_dim = net.params[pr][1].data.shape
+			else:
+				bias_dim = (net.params[pr][0].data.shape[0], )
+			biasSize = np.prod(bias_dim)
+			conv_bias = np.reshape(netWeights[count:count+biasSize], bias_dim)
+			if len(net.params[pr]) > 1:
+				assert(bias_dim == net.params[pr][1].data.shape)
+				net.params[pr][1].data[...] = conv_bias
+				conv_bias = None
+			count = count + biasSize
+			# batch_norm
+			next_layer = net.layers[lidx+1]
+			if next_layer.type == 'BatchNorm':
+				bn_dims = (3, net.params[pr][0].data.shape[0])
+				bnSize = np.prod(bn_dims)
+				batch_norm = np.reshape(netWeights[count:count+bnSize], bn_dims)
+				count = count + bnSize
+			# weights
 			dims = net.params[pr][0].data.shape
-			if transFlag: # need transpose for fc layers
-				net.params[pr][0].data[...] = np.reshape(transpose_matrix(netWeights[count:count+weightSize], dims[1],dims[0]), dims)
+			weightSize = np.prod(dims)
+			net.params[pr][0].data[...] = np.reshape(netWeights[count:count+weightSize], dims)
+			count = count + weightSize
+		elif layer.type == 'InnerProduct':
+			print pr+"(fc)"
+			# bias
+			biasSize = np.prod(net.params[pr][1].data.shape)
+			net.params[pr][1].data[...] = np.reshape(netWeights[count:count+biasSize], net.params[pr][1].data.shape)
+			count = count + biasSize
+			# weights
+			dims = net.params[pr][0].data.shape
+			weightSize = np.prod(dims)
+			if transFlag:
+				net.params[pr][0].data[...] = np.reshape(netWeights[count:count+weightSize], (dims[1], dims[0])).transpose()
 			else:
 				net.params[pr][0].data[...] = np.reshape(netWeights[count:count+weightSize], dims)
-		count = count + weightSize
-	print count
+			count = count + weightSize
+		elif layer.type == 'BatchNorm':
+			print pr+"(batchnorm)"
+			net.params[pr][0].data[...] = batch_norm[1]	# mean
+			net.params[pr][1].data[...] = batch_norm[2]	# variance
+			net.params[pr][2].data[...] = 1.0	# scale factor
+		elif layer.type == 'Scale':
+			print pr+"(scale)"
+			net.params[pr][0].data[...] = batch_norm[0]	# scale
+			batch_norm = None
+			if len(net.params[pr]) > 1:
+				net.params[pr][1].data[...] = conv_bias	# bias
+				conv_bias = None
+		else:
+			print "WARNING: unsupported layer, "+pr
+	if np.prod(netWeights.shape) != count:
+		print "ERROR: size mismatch: %d" % count
 	net.save(caffemodel_filename)		
 		
 if __name__=='__main__':	

--- a/create_yolo_prototxt.py
+++ b/create_yolo_prototxt.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from ConfigParser import ConfigParser
 from collections import OrderedDict
+import argparse
 import logging
 import os
 import sys

--- a/create_yolo_prototxt.py
+++ b/create_yolo_prototxt.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+from ConfigParser import ConfigParser
+from collections import OrderedDict
+import logging
+import os
+import sys
+
+class CaffeLayerGenerator(object):
+    def __init__(self, name, ltype):
+        self.name = name
+        self.bottom = []
+        self.top = []
+        self.type = ltype
+    def get_template(self):
+        return """
+layer {{{{
+  name: "{}"
+  type: "{}"
+  bottom: "{}"
+  top: "{}"{{}}
+}}}}""".format(self.name, self.type, self.bottom[0], self.top[0])
+
+class CaffeInputLayer(CaffeLayerGenerator):
+    def __init__(self, name, channels, width, height):
+        super(CaffeInputLayer, self).__init__(name, 'Input')
+        self.channels = channels
+        self.width = width
+        self.height = height
+    def write(self, f):
+        f.write("""
+input: "{}"
+input_shape {{
+  dim: 1
+  dim: {}
+  dim: {}
+  dim: {}
+}}""".format(self.name, self.channels, self.width, self.height))
+
+class CaffeConvolutionLayer(CaffeLayerGenerator):
+    def __init__(self, name, filters, ksize=None, stride=None, pad=None, bias=True):
+        super(CaffeConvolutionLayer, self).__init__(name, 'Convolution')
+        self.filters = filters
+        self.ksize = ksize
+        self.stride = stride
+        self.pad = pad
+        self.bias = bias
+    def write(self, f):
+        opts = ['']
+        if self.ksize is not None: opts.append('kernel_size: {}'.format(self.ksize))
+        if self.stride is not None: opts.append('stride: {}'.format(self.stride))
+        if self.pad is not None: opts.append('pad: {}'.format(self.pad))
+        if not self.bias: opts.append('bias_term: false')
+        param_str = """
+  convolution_param {{
+    num_output: {}{}
+  }}""".format(self.filters, '\n    '.join(opts))
+        f.write(self.get_template().format(param_str))
+
+class CaffePoolingLayer(CaffeLayerGenerator):
+    def __init__(self, name, pooltype, ksize=None, stride=None, pad=None, global_pooling=None):
+        super(CaffePoolingLayer, self).__init__(name, 'Pooling')
+        self.pooltype = pooltype
+        self.ksize = ksize
+        self.stride = stride
+        self.pad = pad
+        self.global_pooling = global_pooling
+    def write(self, f):
+        opts = ['']
+        if self.ksize is not None: opts.append('kernel_size: {}'.format(self.ksize))
+        if self.stride is not None: opts.append('stride: {}'.format(self.stride))
+        if self.pad is not None: opts.append('pad: {}'.format(self.pad))
+        if self.global_pooling is not None: opts.append('global_pooling: {}'.format('True' if self.global_pooling else 'False'))
+        param_str = """
+  pooling_param {{
+    pool: {}{}
+  }}""".format(self.pooltype, '\n    '.join(opts))
+        f.write(self.get_template().format(param_str))
+
+class CaffeInnerProductLayer(CaffeLayerGenerator):
+    def __init__(self, name, num_output):
+        super(CaffeInnerProductLayer, self).__init__(name, 'InnerProduct')
+        self.num_output = num_output
+    def write(self, f):
+        param_str = """
+  inner_product_param {{
+    num_output: {}
+  }}""".format(self.num_output)
+        f.write(self.get_template().format(param_str))
+
+class CaffeBatchNormLayer(CaffeLayerGenerator):
+    def __init__(self, name):
+        super(CaffeBatchNormLayer, self).__init__(name, 'BatchNorm')
+    def write(self, f):
+        param_str = """
+  batch_norm_param {
+    use_global_stats: true
+  }"""
+        f.write(self.get_template().format(param_str))
+
+class CaffeScaleLayer(CaffeLayerGenerator):
+    def __init__(self, name):
+        super(CaffeScaleLayer, self).__init__(name, 'Scale')
+    def write(self, f):
+        param_str = """
+  scale_param {
+    bias_term: true
+  }"""
+        f.write(self.get_template().format(param_str))
+
+class CaffeReluLayer(CaffeLayerGenerator):
+    def __init__(self, name, negslope=None):
+        super(CaffeReluLayer, self).__init__(name, 'Relu')
+        self.negslope = negslope
+    def write(self, f):
+        param_str = ""
+        if self.negslope is not None:
+            param_str = """
+  relu_param {{
+    negative_slope: {}
+  }}""".format(self.negslope)
+        f.write(self.get_template().format(param_str))
+
+class CaffeDropoutLayer(CaffeLayerGenerator):
+    def __init__(self, name, prob):
+        super(CaffeDropoutLayer, self).__init__(name, 'Dropout')
+        self.prob = prob
+    def write(self, f):
+        param_str = """
+  dropout_param {{
+    dropout_ratio: {}
+  }}""".format(self.prob)
+        f.write(self.get_template().format(param_str))
+
+class CaffeSoftmaxLayer(CaffeLayerGenerator):
+    def __init__(self, name):
+        super(CaffeSoftmaxLayer, self).__init__(name, 'Softmax')
+    def write(self, f):
+        f.write(self.get_template().format(""))
+
+class CaffeProtoGenerator:
+    def __init__(self, name):
+        self.name = name
+        self.sections = []
+        self.lnum = 0
+        self.layer = None
+    def add_layer(self, l):
+        self.sections.append( l )
+    def add_input_layer(self, items):
+        self.lnum = 0
+        lname = "data"
+        self.layer = CaffeInputLayer(lname, items['channels'], items['width'], items['height'])
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_convolution_layer(self, items):
+        self.lnum += 1
+        prev_blob = self.layer.top[0]
+        lname = "conv"+str(self.lnum)
+        filters = items['filters']
+        ksize = items['size'] if 'size' in items else None
+        stride = items['stride'] if 'stride' in items else None
+        pad = items['pad'] if 'pad' in items else None
+        bias = not bool(items['batch_normalize']) if 'batch_normalize' in items else True
+        self.layer = CaffeConvolutionLayer( lname, filters, ksize=ksize, stride=stride, pad=pad, bias=bias )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_innerproduct_layer(self, items):
+        self.lnum += 1
+        prev_blob = self.layer.top[0]
+        lname = "fc"+str(self.lnum)
+        num_output = items['output']
+        self.layer = CaffeInnerProductLayer( lname, num_output )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_pooling_layer(self, ltype, items, global_pooling=None):
+        prev_blob = self.layer.top[0]
+        lname = "pool"+str(self.lnum)
+        ksize = items['size'] if 'size' in items else None
+        stride = items['stride'] if 'stride' in items else None
+        pad = items['pad'] if 'pad' in items else None
+        self.layer = CaffePoolingLayer( lname, ltype, ksize=ksize, stride=stride, pad=pad, global_pooling=global_pooling )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_batchnorm_layer(self, items):
+        prev_blob = self.layer.top[0]
+        lname = "bn"+str(self.lnum)
+        self.layer = CaffeBatchNormLayer( lname )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_scale_layer(self, items):
+        prev_blob = self.layer.top[0]
+        lname = "scale"+str(self.lnum)
+        self.layer = CaffeScaleLayer( lname )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def add_relu_layer(self, items):
+        prev_blob = self.layer.top[0]
+        lname = "relu"+str(self.lnum)
+        self.layer = CaffeReluLayer( lname )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( prev_blob )     # loopback
+        self.add_layer( self.layer )
+    def add_dropout_layer(self, items):
+        prev_blob = self.layer.top[0]
+        lname = "drop"+str(self.lnum)
+        self.layer = CaffeDropoutLayer( lname, items['probability'] )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( prev_blob )     # loopback
+        self.add_layer( self.layer )
+    def add_softmax_layer(self, items):
+        prev_blob = self.layer.top[0]
+        lname = "prob"
+        self.layer = CaffeSoftmaxLayer( lname )
+        self.layer.bottom.append( prev_blob )
+        self.layer.top.append( lname )
+        self.add_layer( self.layer )
+    def finalize(self, name):
+        self.layer.top[0] = name    # replace
+    def write(self, fname):
+        with open(fname, 'w') as f:
+            f.write('name: "{}"'.format(self.name))
+            for sec in self.sections:
+                sec.write(f)
+        logging.info('{} is generated'.format(fname))
+
+###################################################################33
+class uniqdict(OrderedDict):
+    _unique = 0
+    def __setitem__(self, key, val):
+        if isinstance(val, OrderedDict):
+            self._unique += 1
+            key += "_"+str(self._unique)
+        OrderedDict.__setitem__(self, key, val)
+
+def convert(cfgfile, ptxtfile):
+    #
+    parser = ConfigParser(dict_type=uniqdict)
+    parser.read(cfgfile)
+    netname = os.path.basename(cfgfile).split('.')[0]
+    #print netname
+    gen = CaffeProtoGenerator(netname)
+    for section in parser.sections():
+        _section = section.split('_')[0]
+        if _section in ["crop", "cost"]:
+            continue
+        #
+        batchnorm_followed = False
+        relu_followed = False
+        items = dict(parser.items(section))
+        if 'batch_normalize' in items and items['batch_normalize']:
+            batchnorm_followed = True
+        if 'activation' in items and items['activation'] != 'linear':
+            relu_followed = True
+        #
+        if _section == 'net':
+            gen.add_input_layer(items)
+        elif _section == 'convolutional':
+            gen.add_convolution_layer(items)
+            if batchnorm_followed:
+                gen.add_batchnorm_layer(items)
+                gen.add_scale_layer(items)
+            if relu_followed:
+                gen.add_relu_layer(items)
+        elif _section == 'connected':
+            gen.add_innerproduct_layer(items)
+            if relu_followed:
+                gen.add_relu_layer(items)
+        elif _section == 'maxpool':
+            gen.add_pooling_layer('MAX', items)
+        elif _section == 'avgpool':
+            gen.add_pooling_layer('AVE', items, global_pooling=True)
+        elif _section == 'dropout':
+            gen.add_dropout_layer(items)
+        elif _section == 'softmax':
+            gen.add_softmax_layer(items)
+        else:
+            logging.error("{} layer is not supported".format(_section))
+    #gen.finalize('result')
+    gen.write(ptxtfile)
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert YOLO cfg to Caffe prototxt')
+    parser.add_argument('cfg', type=str, help='YOLO cfg')
+    parser.add_argument('prototxt', type=str, help='Caffe prototxt')
+    args = parser.parse_args()
+
+    convert(args.cfg, args.prototxt)
+
+if __name__ == "__main__":
+    main()
+
+# vim:sw=4:ts=4:et

--- a/prototxt/yolo_tiny_deploy.prototxt
+++ b/prototxt/yolo_tiny_deploy.prototxt
@@ -1,4 +1,4 @@
-name: "YOLONet"
+name: "tiny-yolo"
 input: "data"
 input_shape {
   dim: 1
@@ -16,22 +16,40 @@ layer {
     num_output: 16
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn1"
+  type: "BatchNorm"
+  bottom: "conv1"
+  top: "bn1"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale1"
+  type: "Scale"
+  bottom: "bn1"
+  top: "scale1"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu1"
   type: "ReLU"
-  bottom: "conv1"
-  top: "conv1"
-  relu_param{
+  bottom: "scale1"
+  top: "scale1"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool1"
   type: "Pooling"
-  bottom: "conv1"
+  bottom: "scale1"
   top: "pool1"
   pooling_param {
     pool: MAX
@@ -39,7 +57,8 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv2"
   type: "Convolution"
   bottom: "pool1"
@@ -48,22 +67,40 @@ layer{
     num_output: 32
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn2"
+  type: "BatchNorm"
+  bottom: "conv2"
+  top: "bn2"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale2"
+  type: "Scale"
+  bottom: "bn2"
+  top: "scale2"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu2"
   type: "ReLU"
-  bottom: "conv2"
-  top: "conv2"
-  relu_param{
+  bottom: "scale2"
+  top: "scale2"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool2"
   type: "Pooling"
-  bottom: "conv2"
+  bottom: "scale2"
   top: "pool2"
   pooling_param {
     pool: MAX
@@ -71,7 +108,8 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv3"
   type: "Convolution"
   bottom: "pool2"
@@ -80,22 +118,40 @@ layer{
     num_output: 64
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn3"
+  type: "BatchNorm"
+  bottom: "conv3"
+  top: "bn3"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale3"
+  type: "Scale"
+  bottom: "bn3"
+  top: "scale3"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu3"
   type: "ReLU"
-  bottom: "conv3"
-  top: "conv3"
-  relu_param{
+  bottom: "scale3"
+  top: "scale3"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
-layer{
+layer {
   name: "pool3"
   type: "Pooling"
-  bottom: "conv3"
+  bottom: "scale3"
   top: "pool3"
   pooling_param {
     pool: MAX
@@ -103,7 +159,8 @@ layer{
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv4"
   type: "Convolution"
   bottom: "pool3"
@@ -112,22 +169,40 @@ layer{
     num_output: 128
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn4"
+  type: "BatchNorm"
+  bottom: "conv4"
+  top: "bn4"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale4"
+  type: "Scale"
+  bottom: "bn4"
+  top: "scale4"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu4"
   type: "ReLU"
-  bottom: "conv4"
-  top: "conv4"
-  relu_param{
+  bottom: "scale4"
+  top: "scale4"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool4"
   type: "Pooling"
-  bottom: "conv4"
+  bottom: "scale4"
   top: "pool4"
   pooling_param {
     pool: MAX
@@ -135,7 +210,8 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv5"
   type: "Convolution"
   bottom: "pool4"
@@ -144,22 +220,40 @@ layer{
     num_output: 256
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn5"
+  type: "BatchNorm"
+  bottom: "conv5"
+  top: "bn5"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale5"
+  type: "Scale"
+  bottom: "bn5"
+  top: "scale5"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu5"
   type: "ReLU"
-  bottom: "conv5"
-  top: "conv5"
-  relu_param{
+  bottom: "scale5"
+  top: "scale5"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool5"
   type: "Pooling"
-  bottom: "conv5"
+  bottom: "scale5"
   top: "pool5"
   pooling_param {
     pool: MAX
@@ -167,7 +261,8 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv6"
   type: "Convolution"
   bottom: "pool5"
@@ -176,22 +271,40 @@ layer{
     num_output: 512
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn6"
+  type: "BatchNorm"
+  bottom: "conv6"
+  top: "bn6"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale6"
+  type: "Scale"
+  bottom: "bn6"
+  top: "scale6"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu6"
   type: "ReLU"
-  bottom: "conv6"
-  top: "conv6"
-  relu_param{
+  bottom: "scale6"
+  top: "scale6"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool6"
   type: "Pooling"
-  bottom: "conv6"
+  bottom: "scale6"
   top: "pool6"
   pooling_param {
     pool: MAX
@@ -199,101 +312,91 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv7"
   type: "Convolution"
   bottom: "pool6"
   top: "conv7"
   convolution_param {
     num_output: 1024
-    pad: 1
     kernel_size: 3
-    stride: 1
+    pad: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn7"
+  type: "BatchNorm"
+  bottom: "conv7"
+  top: "bn7"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale7"
+  type: "Scale"
+  bottom: "bn7"
+  top: "scale7"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu7"
   type: "ReLU"
-  bottom: "conv7"
-  top: "conv7"
-  relu_param{
+  bottom: "scale7"
+  top: "scale7"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
-layer{
+
+layer {
   name: "conv8"
   type: "Convolution"
-  bottom: "conv7"
+  bottom: "scale7"
   top: "conv8"
   convolution_param {
-    num_output: 1024
+    num_output: 256
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
+  }
+}
+layer {
+  name: "bn8"
+  type: "BatchNorm"
+  bottom: "conv8"
+  top: "bn8"
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale8"
+  type: "Scale"
+  bottom: "bn8"
+  top: "scale8"
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu8"
   type: "ReLU"
-  bottom: "conv8"
-  top: "conv8"
-  relu_param{
+  bottom: "scale8"
+  top: "scale8"
+  relu_param {
     negative_slope: 0.1
-  }		
-}
-layer{
-  name: "conv9"
-  type: "Convolution"
-  bottom: "conv8"
-  top: "conv9"
-  convolution_param {
-    num_output: 1024
-    kernel_size: 3
-    pad: 1
-    stride: 1
   }
-}
-layer {
-  name: "relu9"
-  type: "ReLU"
-  bottom: "conv9"
-  top: "conv9"
-  relu_param{
-    negative_slope: 0.1
-  }		
-}
-layer{
-  name: "fc10"
-  type: "InnerProduct"
-  bottom: "conv9"
-  top: "fc10"
-  inner_product_param {
-    num_output: 256
-  }
-}
-layer {
-  name: "fc11"
-  type: "InnerProduct"
-  bottom: "fc10"
-  top: "fc11"
-  inner_product_param {
-    num_output: 4096
-  }
-}
-layer {
-  name: "relu11"
-  type: "ReLU"
-  bottom: "fc11"
-  top: "fc11"
-  relu_param{
-    negative_slope: 0.1
-  }		
 }
 
 layer {
-  name: "fc12"
+  name: "fc9"
   type: "InnerProduct"
-  bottom: "fc11"
+  bottom: "scale8"
   top: "result"
   inner_product_param {
     num_output: 1470

--- a/prototxt/yolo_tiny_train_val.prototxt
+++ b/prototxt/yolo_tiny_train_val.prototxt
@@ -12,34 +12,82 @@ layer {
   type: "Convolution"
   bottom: "data"
   top: "conv1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 16
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn1"
+  type: "BatchNorm"
+  bottom: "conv1"
+  top: "bn1"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn1"
+  type: "BatchNorm"
+  bottom: "conv1"
+  top: "bn1"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale1"
+  type: "Scale"
+  bottom: "bn1"
+  top: "scale1"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu1"
   type: "ReLU"
-  bottom: "conv1"
-  top: "conv1"
-  relu_param{
+  bottom: "scale1"
+  top: "scale1"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool1"
   type: "Pooling"
-  bottom: "conv1"
+  bottom: "scale1"
   top: "pool1"
   pooling_param {
     pool: MAX
@@ -47,39 +95,88 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv2"
   type: "Convolution"
   bottom: "pool1"
   top: "conv2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 32
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn2"
+  type: "BatchNorm"
+  bottom: "conv2"
+  top: "bn2"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn2"
+  type: "BatchNorm"
+  bottom: "conv2"
+  top: "bn2"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale2"
+  type: "Scale"
+  bottom: "bn2"
+  top: "scale2"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu2"
   type: "ReLU"
-  bottom: "conv2"
-  top: "conv2"
-  relu_param{
+  bottom: "scale2"
+  top: "scale2"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool2"
   type: "Pooling"
-  bottom: "conv2"
+  bottom: "scale2"
   top: "pool2"
   pooling_param {
     pool: MAX
@@ -87,39 +184,88 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv3"
   type: "Convolution"
   bottom: "pool2"
   top: "conv3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 64
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn3"
+  type: "BatchNorm"
+  bottom: "conv3"
+  top: "bn3"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn3"
+  type: "BatchNorm"
+  bottom: "conv3"
+  top: "bn3"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale3"
+  type: "Scale"
+  bottom: "bn3"
+  top: "scale3"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu3"
   type: "ReLU"
-  bottom: "conv3"
-  top: "conv3"
-  relu_param{
+  bottom: "scale3"
+  top: "scale3"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
-layer{
+layer {
   name: "pool3"
   type: "Pooling"
-  bottom: "conv3"
+  bottom: "scale3"
   top: "pool3"
   pooling_param {
     pool: MAX
@@ -127,39 +273,88 @@ layer{
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv4"
   type: "Convolution"
   bottom: "pool3"
   top: "conv4"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 128
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn4"
+  type: "BatchNorm"
+  bottom: "conv4"
+  top: "bn4"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn4"
+  type: "BatchNorm"
+  bottom: "conv4"
+  top: "bn4"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale4"
+  type: "Scale"
+  bottom: "bn4"
+  top: "scale4"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu4"
   type: "ReLU"
-  bottom: "conv4"
-  top: "conv4"
-  relu_param{
+  bottom: "scale4"
+  top: "scale4"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool4"
   type: "Pooling"
-  bottom: "conv4"
+  bottom: "scale4"
   top: "pool4"
   pooling_param {
     pool: MAX
@@ -167,39 +362,88 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv5"
   type: "Convolution"
   bottom: "pool4"
   top: "conv5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 256
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn5"
+  type: "BatchNorm"
+  bottom: "conv5"
+  top: "bn5"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn5"
+  type: "BatchNorm"
+  bottom: "conv5"
+  top: "bn5"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale5"
+  type: "Scale"
+  bottom: "bn5"
+  top: "scale5"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu5"
   type: "ReLU"
-  bottom: "conv5"
-  top: "conv5"
-  relu_param{
+  bottom: "scale5"
+  top: "scale5"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool5"
   type: "Pooling"
-  bottom: "conv5"
+  bottom: "scale5"
   top: "pool5"
   pooling_param {
     pool: MAX
@@ -207,39 +451,88 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv6"
   type: "Convolution"
   bottom: "pool5"
   top: "conv6"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 512
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn6"
+  type: "BatchNorm"
+  bottom: "conv6"
+  top: "bn6"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn6"
+  type: "BatchNorm"
+  bottom: "conv6"
+  top: "bn6"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale6"
+  type: "Scale"
+  bottom: "bn6"
+  top: "scale6"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu6"
   type: "ReLU"
-  bottom: "conv6"
-  top: "conv6"
-  relu_param{
+  bottom: "scale6"
+  top: "scale6"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
 layer {
   name: "pool6"
   type: "Pooling"
-  bottom: "conv6"
+  bottom: "scale6"
   top: "pool6"
   pooling_param {
     pool: MAX
@@ -247,142 +540,185 @@ layer {
     stride: 2
   }
 }
-layer{
+
+layer {
   name: "conv7"
   type: "Convolution"
   bottom: "pool6"
   top: "conv7"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 1024
-    pad: 1
     kernel_size: 3
-    stride: 1
+    pad: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn7"
+  type: "BatchNorm"
+  bottom: "conv7"
+  top: "bn7"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn7"
+  type: "BatchNorm"
+  bottom: "conv7"
+  top: "bn7"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale7"
+  type: "Scale"
+  bottom: "bn7"
+  top: "scale7"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu7"
   type: "ReLU"
-  bottom: "conv7"
-  top: "conv7"
-  relu_param{
+  bottom: "scale7"
+  top: "scale7"
+  relu_param {
     negative_slope: 0.1
-  }		
+  }
 }
-layer{
-  name: "conv8"
+#layer {
+#  name: "drop7"
+#  type: "Dropout"
+#  bottom: "scale7"
+#  top: "scale7"
+#  dropout_param {
+#    dropout_ratio: 0.5
+#  }
+#}
+
+layer {
+  name: "conv8_y"
   type: "Convolution"
-  bottom: "conv7"
+  bottom: "scale7"
   top: "conv8"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
-    num_output: 1024
+    num_output: 256
     kernel_size: 3
     pad: 1
-    stride: 1
+    bias_term: false
     weight_filler {
-      type: "gaussian"
-      std: 0.01
+      type: "xavier"
     }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
+  }
+}
+layer {
+  name: "bn8"
+  type: "BatchNorm"
+  bottom: "conv8"
+  top: "bn8"
+  include { phase: TRAIN }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  batch_norm_param {
+    use_global_stats: false
+  }
+}
+layer {
+  name: "bn8"
+  type: "BatchNorm"
+  bottom: "conv8"
+  top: "bn8"
+  include { phase: TEST }
+  batch_norm_param {
+    use_global_stats: true
+  }
+}
+layer {
+  name: "scale8"
+  type: "Scale"
+  bottom: "bn8"
+  top: "scale8"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  scale_param {
+    bias_term: true
   }
 }
 layer {
   name: "relu8"
   type: "ReLU"
-  bottom: "conv8"
-  top: "conv8"
-  relu_param{
+  bottom: "scale8"
+  top: "scale8"
+  relu_param {
     negative_slope: 0.1
-  }		
-}
-layer{
-  name: "conv9"
-  type: "Convolution"
-  bottom: "conv8"
-  top: "conv9"
-  convolution_param {
-    num_output: 1024
-    kernel_size: 3
-    pad: 1
-    stride: 1
-    weight_filler {
-      type: "gaussian"
-      std: 0.01
-    }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
   }
-}
-layer {
-  name: "relu9"
-  type: "ReLU"
-  bottom: "conv9"
-  top: "conv9"
-  relu_param{
-    negative_slope: 0.1
-  }		
-}
-layer{
-  name: "fc10"
-  type: "InnerProduct"
-  bottom: "conv9"
-  top: "fc10"
-  inner_product_param {
-    num_output: 256
-    weight_filler {
-      type: "gaussian"
-      std: 0.01
-    }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
-  }
-}
-layer {
-  name: "fc11"
-  type: "InnerProduct"
-  bottom: "fc10"
-  top: "fc11"
-  inner_product_param {
-    num_output: 4096
-    weight_filler {
-      type: "gaussian"
-      std: 0.01
-    }
-    bias_filler {
-      type: "constant"
-      value: 0
-    }
-  }
-}
-layer {
-  name: "relu11"
-  type: "ReLU"
-  bottom: "fc11"
-  top: "fc11"
-  relu_param{
-    negative_slope: 0.1
-  }		
 }
 
 layer {
-  name: "fc12"
+  name: "fc9"
   type: "InnerProduct"
-  bottom: "fc11"
+  bottom: "scale8"
   top: "result"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   inner_product_param {
     num_output: 1470
     weight_filler {

--- a/yolo_main.py
+++ b/yolo_main.py
@@ -44,7 +44,7 @@ def interpret_output(output, img_width, img_height):
 	filter_mat_boxes = np.nonzero(filter_mat_probs)
 	boxes_filtered = boxes[filter_mat_boxes[0],filter_mat_boxes[1],filter_mat_boxes[2]]
 	probs_filtered = probs[filter_mat_probs]
-	classes_num_filtered = np.argmax(filter_mat_probs,axis=3)[filter_mat_boxes[0],filter_mat_boxes[1],filter_mat_boxes[2]] 
+	classes_num_filtered = np.argmax(probs,axis=3)[filter_mat_boxes[0],filter_mat_boxes[1],filter_mat_boxes[2]]
 
 	argsort = np.array(np.argsort(probs_filtered))[::-1]
 	boxes_filtered = boxes_filtered[argsort]

--- a/yolo_main.py
+++ b/yolo_main.py
@@ -139,7 +139,6 @@ def main(argv):
 	inputs = img
 	transformer = caffe.io.Transformer({'data': net.blobs['data'].data.shape})
 	transformer.set_transpose('data', (2,0,1))
-	transformer.set_channel_swap('data', (2,1,0))
 	start = datetime.now()
 	out = net.forward_all(data=np.asarray([transformer.preprocess('data', inputs)]))
 	end = datetime.now()


### PR DESCRIPTION
I add a function to support batch normalization layer included in the recent darknet models.
There ware two ways to include batch norm layer in darknet. One is batch_norm layer and the other one is batch_normalization feature in convolutional layer. This update support only the second one, which is more common.
I also remove channel swap for input data. Darknet uses RGB order, not BGR in Caffe.